### PR TITLE
fix: 修复运行时版本太老，vercel 部署失败的问题: vercel-php@0.5.2 -> vercel-php@0.6.0

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,16 +1,16 @@
 {
-    "functions": {
-        "api/index.php": {
-            "runtime": "vercel-php@0.5.2",
-            "excludeFiles": "{test/**}",
-            "memory": 1024,
-            "maxDuration": 10
-        }
-    },
-    "routes": [
-        {
-            "src": "/(\\w*)\\.(?:jpg|jpeg|png|gif|bmp|webp)",
-            "dest": "/api/index.php?id=$1"
-        }
-    ]
+  "functions": {
+    "api/index.php": {
+      "runtime": "vercel-php@0.6.0",
+      "excludeFiles": "{test/**}",
+      "memory": 1024,
+      "maxDuration": 10
+    }
+  },
+  "routes": [
+    {
+      "src": "/(\\w*)\\.(?:jpg|jpeg|png|gif|bmp|webp)",
+      "dest": "/api/index.php?id=$1"
+    }
+  ]
 }


### PR DESCRIPTION
修复运行时版本太老，vercel 部署失败的问题

Error: The Runtime "vercel-php@0.5.2" is using "nodejs14.x", which is discontinued. Please upgrade your Runtime to a more recent version or consult the author for more details.